### PR TITLE
Enable Ti Stealth as part of Alloy-Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is an alloy bootstrap with
  * [LTSS](https://github.com/dbankier/ltss) an Alloy tss pre-processor inspired by less
  * [TiCons](https://github.com/fokkezb/ticons-cli) to generate icons and splash screens
  * [TiShadow](https://github.com/dbankier/TiShadow) run tests or execute code snippets live across all running iOS and Android devices
+ * [TiStealth](https://github.com/fokkezb/ti-stealth), a module to replace console log calls with NOOPs which can later be restored
 
 
 ## Prerequisites

--- a/app/alloy.jmk
+++ b/app/alloy.jmk
@@ -1,0 +1,7 @@
+task("post:compile", function(event, logger) {
+  if (event.alloyConfig.deployType === 'production') {
+    require('ti-stealth').enable(event.dir.resources, {
+      notLevels: []
+    });
+  }
+});


### PR DESCRIPTION
Added `alloy.jmk`, in order to use Ti Stealth in production builds.
