### PR TITLE
Update alloy.jmk

### DIFF
--- a/app/alloy.jmk
+++ b/app/alloy.jmk
@@ -1,5 +1,5 @@
 task("post:compile", function(event, logger) {
-  if (event.alloyConfig.deployType === 'production') {
+  if (event.alloyConfig.deploytype === 'production') {
     require('ti-stealth').enable(event.dir.resources, {
       notLevels: []
     });


### PR DESCRIPTION
fixed `deploytype` attribute case. The `deployType` key does not exist and therefore the hook content is ignored at compile time.